### PR TITLE
Fix test error on Admin UI with chart release 2.0.8 and upgrade to Playwright 1.32.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Once the setup and configuration is completed, you can run several commands:
 # runs the end-to-end tests (see https://playwright.dev/docs/running-tests)
 npx playwright test
 
+# run the tests from the test browser (really cool to see & debug!)
+npx playwright test --ui
+
 # opens last HTML report run
 npx playwright show-report
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@cucumber/cucumber": "^9.0.1",
-        "@playwright/test": "^1.31.1",
+        "@playwright/test": "^1.32.0",
         "@typescript-eslint/eslint-plugin": "^5.56.0",
         "@typescript-eslint/parser": "^5.56.0",
         "cucumber-tsflow": "^4.0.0-rc.7",
@@ -930,13 +930,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.31.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.31.2.tgz",
-      "integrity": "sha512-BYVutxDI4JeZKV1+ups6dt5WiqKhjBtIYowyZIJ3kBDmJgsuPKsqqKNIMFbUePLSCmp2cZu+BDL427RcNKTRYw==",
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.1.tgz",
+      "integrity": "sha512-FTwjCuhlm1qHUGf4hWjfr64UMJD/z0hXYbk+O387Ioe6WdyZQ+0TBDAc6P+pHjx2xCv1VYNgrKbYrNixFWy4Dg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.31.2"
+        "playwright-core": "1.32.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5074,9 +5074,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.31.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.31.2.tgz",
-      "integrity": "sha512-a1dFgCNQw4vCsG7bnojZjDnPewZcw7tZUNFN0ZkcLYKj+mPmXvg4MpaaKZ5SgqPsOmqIf2YsVRkgqiRDxD+fDQ==",
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.1.tgz",
+      "integrity": "sha512-KZYUQC10mXD2Am1rGlidaalNGYk3LU1vZqqNk0gT4XPty1jOqgup8KDP8l2CUlqoNKhXM5IfGjWgW37xvGllBA==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"
@@ -7635,14 +7635,14 @@
       }
     },
     "@playwright/test": {
-      "version": "1.31.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.31.2.tgz",
-      "integrity": "sha512-BYVutxDI4JeZKV1+ups6dt5WiqKhjBtIYowyZIJ3kBDmJgsuPKsqqKNIMFbUePLSCmp2cZu+BDL427RcNKTRYw==",
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.1.tgz",
+      "integrity": "sha512-FTwjCuhlm1qHUGf4hWjfr64UMJD/z0hXYbk+O387Ioe6WdyZQ+0TBDAc6P+pHjx2xCv1VYNgrKbYrNixFWy4Dg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
         "fsevents": "2.3.2",
-        "playwright-core": "1.31.2"
+        "playwright-core": "1.32.1"
       }
     },
     "@teppeis/multimaps": {
@@ -10803,9 +10803,9 @@
       }
     },
     "playwright-core": {
-      "version": "1.31.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.31.2.tgz",
-      "integrity": "sha512-a1dFgCNQw4vCsG7bnojZjDnPewZcw7tZUNFN0ZkcLYKj+mPmXvg4MpaaKZ5SgqPsOmqIf2YsVRkgqiRDxD+fDQ==",
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.1.tgz",
+      "integrity": "sha512-KZYUQC10mXD2Am1rGlidaalNGYk3LU1vZqqNk0gT4XPty1jOqgup8KDP8l2CUlqoNKhXM5IfGjWgW37xvGllBA==",
       "dev": true
     },
     "preferred-pm": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/devpro/hobbyfarm-e2e-testing#readme",
   "devDependencies": {
     "@cucumber/cucumber": "^9.0.1",
-    "@playwright/test": "^1.31.1",
+    "@playwright/test": "^1.32.0",
     "@typescript-eslint/eslint-plugin": "^5.56.0",
     "@typescript-eslint/parser": "^5.56.0",
     "cucumber-tsflow": "^4.0.0-rc.7",

--- a/src/pages/ui/login.page.ts
+++ b/src/pages/ui/login.page.ts
@@ -16,7 +16,8 @@ export class LoginPage {
 
   async goto(url: string) {
     await this.page.goto(url);
-    await expect(this.page).toHaveURL(`${url}/login`);
+    // @since chart release 2.0.8 (hobbyfarm/admin-ui:v2.0.3)
+    await expect(this.page).toHaveURL(`${url}/login?returnUrl=%2Fapp%2Fhome`);
   }
 
   async fillCredentialsAndSubmit(headerTitle: string, emailAddress: string, password: string): Promise<HomePage> {


### PR DESCRIPTION
Features

* Upgrade to Playwright 1.32.0 to be able to run `npx playwright test --ui`

Fixes

* Update Admin UI logout URL since chart release 2.0.8 (hobbyfarm/admin-ui:v2.0.3)
